### PR TITLE
feat: add /call4speakers and /call4sponsors redirect pages

### DIFF
--- a/src/pages/call4speakers.astro
+++ b/src/pages/call4speakers.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Loader from "../components/common/Loader.astro";
+
+const title = "Call for Speakers | GDG Tarija";
+const description =
+  "Conviértete en speaker del Google Developer Group Tarija.";
+const image =
+  "https://res.cloudinary.com/dopkch3x9/image/upload/w_1200,h_1200,c_fill,f_auto,q_auto:good/v1751748539/logo_GDG_dgigmw.png";
+
+const redirectUrl = "https://forms.gle/";
+---
+
+<Layout title={title} description={description} image={image}>
+  <Fragment slot="head">
+    <meta http-equiv="refresh" content={`2;url=${redirectUrl}`} />
+  </Fragment>
+
+  <main
+    class="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-4"
+  >
+    <Loader
+      text="Redirigiendo..."
+      subtext="Te estamos llevando al formulario para speakers."
+    />
+  </main>
+</Layout>

--- a/src/pages/call4speakers.astro
+++ b/src/pages/call4speakers.astro
@@ -8,7 +8,8 @@ const description =
 const image =
   "https://res.cloudinary.com/dopkch3x9/image/upload/w_1200,h_1200,c_fill,f_auto,q_auto:good/v1751748539/logo_GDG_dgigmw.png";
 
-const redirectUrl = "https://forms.gle/";
+const redirectUrl =
+  "https://docs.google.com/forms/d/e/1FAIpQLSd7NcW_BpP1R5npNuWp9mXJunx6sHoKq99h85d3argIlIXM1A/viewform";
 ---
 
 <Layout title={title} description={description} image={image}>

--- a/src/pages/call4sponsors.astro
+++ b/src/pages/call4sponsors.astro
@@ -8,7 +8,8 @@ const description =
 const image =
   "https://res.cloudinary.com/dopkch3x9/image/upload/w_1200,h_1200,c_fill,f_auto,q_auto:good/v1751748539/logo_GDG_dgigmw.png";
 
-const redirectUrl = "https://forms.gle/";
+const redirectUrl =
+  "https://docs.google.com/forms/d/e/1FAIpQLSd7NcW_BpP1R5npNuWp9mXJunx6sHoKq99h85d3argIlIXM1A/viewform";
 ---
 
 <Layout title={title} description={description} image={image}>

--- a/src/pages/call4sponsors.astro
+++ b/src/pages/call4sponsors.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Loader from "../components/common/Loader.astro";
+
+const title = "Call for Sponsors | GDG Tarija";
+const description =
+  "Conviértete en sponsor del Google Developer Group Tarija.";
+const image =
+  "https://res.cloudinary.com/dopkch3x9/image/upload/w_1200,h_1200,c_fill,f_auto,q_auto:good/v1751748539/logo_GDG_dgigmw.png";
+
+const redirectUrl = "https://forms.gle/";
+---
+
+<Layout title={title} description={description} image={image}>
+  <Fragment slot="head">
+    <meta http-equiv="refresh" content={`2;url=${redirectUrl}`} />
+  </Fragment>
+
+  <main
+    class="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-4"
+  >
+    <Loader
+      text="Redirigiendo..."
+      subtext="Te estamos llevando al formulario para sponsors."
+    />
+  </main>
+</Layout>


### PR DESCRIPTION
Closes #106
Closes #107

Agrega las rutas:
- `/call4speakers` — redirige al formulario de inscripción de speakers
- `/call4sponsors` — redirige al formulario de inscripción de sponsors

**Pendiente:** reemplazar las URLs placeholder de Google Forms.